### PR TITLE
[v2] styled-components

### DIFF
--- a/manuscript/react-styling/styled-components.md
+++ b/manuscript/react-styling/styled-components.md
@@ -1,13 +1,13 @@
-## Styled Components in React
+## 리액트에서의 Styled Components
 
-With the previous approaches from CSS-in-CSS, Styled Components is one of several approaches for **CSS-in-JS**. I picked Styled Components because it's the most popular. It comes as a JavaScript dependency, so we must install it on the command line:
+Styled Components는 몇 가지 **CSS-in-JS** 방식 중 하나로, 가장 인기가 많습니다. 자바스크립트 의존성 때문에 커맨드 라인에서 설치합니다.
 
 {title="Command Line",lang="text"}
 ~~~~~~~
 npm install styled-components
 ~~~~~~~
 
-Then import it in your *src/App.js* file:
+그리고 *src/App.js* 파일에서 Styled Components 라이브러리를 가져옵니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 # leanpub-end-insert
 ~~~~~~~
 
-As the name suggests, CSS-in-JS happens in your JavaScript file. In your *src/App.js* file, define your first styled components:
+이름에서 알 수 있듯이 CSS-in-JS는 자바스크립트 파일에 CSS를 작성합니다. *src/App.js* 파일에서 첫 번째 스타일링 된 컴포넌트를 정의하세요.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -39,7 +39,7 @@ const StyledHeadlinePrimary = styled.h1`
 `;
 ~~~~~~~
 
-When using Styled Components, you are using the JavaScript template literals the same way as JavaScript functions. Everything between the backticks can be seen as an argument and the `styled` object gives you access to all the necessary HTML elements (e.g. div, h1) as functions. Once a function is called with the style, it returns a React component that can be used in your App component:
+Styled Components에서는 자바스크립트 함수와 같이 자바스크립트 템플릿 리터럴(template literals)을 사용합니다. 백틱 사이의 모든 것을 인수(argument)로 볼 수 있고, `styled` 객체를 사용하여 필요한 모든 HTML 요소(예: div, h1)에 함수로 접근할 수 있습니다. 스타일로 함수를 호출하면 App 컴포넌트에서 사용할 수 있는 리액트 컴포넌트를 반환(return)합니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -72,7 +72,7 @@ const App = () => {
 };
 ~~~~~~~
 
-This kind of React component follows the same rules as a common React component. Everything passed between its element tags is passed automatically as React `children` prop. For the Item component, we are not using inline styles this time, but defining a dedicated styled component for it. `StyledColumn` receives its styles dynamically using a React prop:
+이렇게 만든 리액트 컴포넌트는 일반적인 리액트 컴포넌트와 동일한 규칙을 따릅니다. 엘리먼트 태그 사이의 모든 것은 리액트 `children` prop으로 자동 전달됩니다. 이번에는 인라인 스타일(inline styles)을 사용하지 않고 전용 스타일로 Item 컴포넌트를 정의합니다. `StyledColumn`은 리액트 prop을 통해 동적으로 스타일이 적용됩니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -102,7 +102,7 @@ const Item = ({ item, onRemoveItem }) => (
 );
 ~~~~~~~
 
-The flexible `width` prop is accessible in the styled component's template literal as an argument of an inline function. The return value from the function is applied there as a string. Since we can use immediate returns when omitting the arrow function's body, it becomes a concise inline function:
+가변적인 `width` prop은 스타일링 된 컴포넌트의 템플릿 리터럴에서 인라인 함수의 인수로 접근할 수 있습니다. 함수의 리턴 값은 문자열로 적용됩니다. 화살표 함수의 본문을 생략하면 즉시 반환할 수 있으므로 간결한 인라인 함수가 됩니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -127,7 +127,7 @@ const StyledColumn = styled.span`
 `;
 ~~~~~~~
 
-Advanced features like CSS nesting are available in Styled Components by default. Nested elements are accessible and the current element can be selected with the `&` CSS operator:
+CSS 중첩(nesting)과 같은 고급 기능은 기본적으로 Styled Components에서 사용할 수 있습니다. 중첩 요소에 접근할 수 있으며 `&` CSS 연산자를 사용하여 현재 요소를 선택할 수 있습니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -146,7 +146,7 @@ const StyledButton = styled.button`
 `;
 ~~~~~~~
 
-You can also create specialized versions of styled components by passing another component to the library's function. The specialized button receives all the base styles from the previously defined StyledButton component:
+`styled` 함수에 다른 컴포넌트를 전달하여 새로운 버전의 컴포넌트를 만들 수도 있습니다. 이전에 정의된 StyledButton 컴포넌트의 모든 기본 스타일이 새로운 버튼에 전달됩니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -165,7 +165,7 @@ const StyledSearchForm = styled.form`
 `;
 ~~~~~~~
 
-When we use a styled component like StyledSearchForm, its underlying elements ( `form`, `button`) are used in the real HTML output. We can continue using the native HTML attributes ( `onSubmit`, `type`, `disabled`) there:
+StyledSearchForm 처럼 스타일링 된 컴포넌트는 그것의 기본 엘리먼트(`form`, `button`)가 실제 HTML로 출력됩니다. 원래의 HTML 속성(`onSubmit`, `type`, `disabled`)을 계속 사용할 수 있습니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -193,7 +193,7 @@ const SearchForm = ({ ... }) => (
 );
 ~~~~~~~
 
-Finally, the InputWithLabel decorated with its yet undefined styled components:
+마지막으로 InputWithLabel 컴포넌트입니다. 아직 스타일을 정의하지 않았습니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -220,7 +220,7 @@ const InputWithLabel = ({ ... }) => {
 };
 ~~~~~~~
 
-And its matching styled components are defined in the same file:
+같은 파일에 해당 스타일을 정의합니다.
 
 {title="src/App.js",lang="javascript"}
 ~~~~~~~
@@ -240,11 +240,11 @@ const StyledInput = styled.input`
 `;
 ~~~~~~~
 
-CSS-in-JS with styled components shifts the focus of defining styles to actual React components. Styled Components are style defined as React components without the intermediate CSS file. If a styled component isn't used in a JavaScript, your IDE/editor will tell you. Styled Components are bundled next to other JavaScript assets in JavaScript files for a production-ready application. There are no extra CSS files, but only JavaScript when using the CSS-in-JS strategy. Both strategies, CSS-in-JS and CSS-in-CSS, and their approaches (e.g. Styled Components and CSS Modules) are popular among React developers. Use what suits you and your team best.
+스타일링 된 컴포넌트가 있는 CSS-in-JS 방식은 스타일 정의의 초점을 실제 리액트 컴포넌트로 바꿉니다. Styled Components는 중간 CSS 파일 없이 리액트 컴포넌트로 정의된 스타일입니다. 자바스크립트에서 스타일링 된 컴포넌트가 사용되지 않으면 IDE/에디터가 알려줍니다. Styled Components는 애플리케이션의 프로덕션 준비 과정에서 다른 자바스크립트 에셋(assets)과 함께 자바스크립트 번들 파일로 묶입니다. CSS-in-JS 방식에서는 별도의 CSS 파일은 없고 자바스크립트만 있습니다. CSS-in-JS와 CSS-in-CSS 방식은(예: Styled Components와 CSS Modules)은 리액트 개발자에게 인기 있습니다. 여러분과 여러분의 팀에 가장 적합한 것을 사용하세요.
 
-### Exercises:
+### 실습하기
 
-* Confirm your [source code for the last section](https://codesandbox.io/s/github/the-road-to-learn-react/hacker-stories/tree/hs/Styled-Components-in-React).
-  * Confirm the [changes from the last section](https://github.com/the-road-to-learn-react/hacker-stories/compare/hs/react-modern-final...hs/Styled-Components-in-React?expand=1).
-* Read more about [Styled Components in React](https://www.robinwieruch.de/react-styled-components).
-  * Usually there is no *src/index.css* file for global styles when using Styled Components. Find out how to use global styles when using Styled Components.
+* [마지막 섹션의 소스 코드](https://codesandbox.io/s/github/the-road-to-learn-react/hacker-stories/tree/hs/Styled-Components-in-React)를 확인하세요.
+  * [마지막 섹션의 변경 사항](https://github.com/the-road-to-learn-react/hacker-stories/compare/hs/react-modern-final...hs/Styled-Components-in-React?expand=1)을 확인하세요.
+* 리액트의 [Styled Components](https://www.robinwieruch.de/react-styled-components)에 대해 자세히 알아보세요.
+  * Styled Components를 사용할 때, 보통 전역 스타일에 대한 *src/index.css* 파일이 없습니다. Styled Components에서 전역 스타일을 사용하는 방법을 알아보세요.

--- a/manuscript/react-styling/styled-components.md
+++ b/manuscript/react-styling/styled-components.md
@@ -244,7 +244,7 @@ const StyledInput = styled.input`
 
 ### 실습하기
 
-* [마지막 섹션의 소스 코드](https://codesandbox.io/s/github/the-road-to-learn-react/hacker-stories/tree/hs/Styled-Components-in-React)를 확인하세요.
-  * [마지막 섹션의 변경 사항](https://github.com/the-road-to-learn-react/hacker-stories/compare/hs/react-modern-final...hs/Styled-Components-in-React?expand=1)을 확인하세요.
+* [마지막 장의 소스 코드](https://codesandbox.io/s/github/the-road-to-learn-react/hacker-stories/tree/hs/Styled-Components-in-React)를 확인하세요.
+  * [마지막 장의 변경 사항](https://github.com/the-road-to-learn-react/hacker-stories/compare/hs/react-modern-final...hs/Styled-Components-in-React?expand=1)을 확인하세요.
 * 리액트의 [Styled Components](https://www.robinwieruch.de/react-styled-components)에 대해 자세히 알아보세요.
   * Styled Components를 사용할 때, 보통 전역 스타일에 대한 *src/index.css* 파일이 없습니다. Styled Components에서 전역 스타일을 사용하는 방법을 알아보세요.


### PR DESCRIPTION
styled-components 번역 초안입니다. 

- JavsScript는 '자바스크립트', React는 '리액트'로 사용했습니다.
- elements의 경우 v1에서는 '엘레먼트'로 표기했으나, 외래어표기법에 따라 '엘리먼트'로 사용했습니다.
- 원문에서 Styled Components 로 표기된 것은 영문 그대로, 문장 중간에 styled components는 '스타일링 된 컴포넌트' 로 바꿔서 사용했습니다.
- 템플릿 리터럴, 인수, 인라인 스타일 등의 표현은 괄호 안에 영문을 병기했습니다.
- prop은 영문을 그대로 사용했습니다. 
- 단어나 문장 대부분을 의역했습니다. 더 좋은 표현이 있다면 의견 주세요.